### PR TITLE
S3: Handle errors returned by MinIO Client ListObjects

### DIFF
--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -156,9 +156,9 @@ func (b *Backend) doList(ctx context.Context, prefix string) (simpleblob.BlobLis
 	})
 	for obj := range objCh {
 		// Handle error returned by MinIO client
-		if obj.Err != nil {
+		if err := convertMinioError(obj.Err); err != nil {
 			metricCallErrors.WithLabelValues("list").Inc()
-			return nil, obj.Err
+			return nil, err
 		}
 
 		metricCalls.WithLabelValues("list").Inc()

--- a/test.sh
+++ b/test.sh
@@ -24,9 +24,8 @@ if [ -z "$SIMPLEBLOB_TEST_S3_CONFIG" ]; then
 
     # Fetch minio if not found
     if ! command -v minio >/dev/null; then
-        source <(go env)
         dst="$GOBIN/minio"
-        curl -v -o "$dst" "https://dl.min.io/server/minio/release/$GOOS-$GOARCH/minio"
+        curl -v -o "$dst" "https://dl.min.io/server/minio/release/$(go env GOOS)-$(go env GOARCH)/minio"
         chmod u+x "$dst"
     fi
 

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -46,6 +46,11 @@ func DoBackendTests(t *testing.T, b simpleblob.Interface) {
 	assert.NoError(t, err)
 	assert.Equal(t, ls.Names(), []string{"bar-1", "bar-2"}) // sorted
 
+	// List with non-existing prefix
+	ls, err = b.List(ctx, "does-not-exist-")
+	assert.NoError(t, err)
+	assert.Nil(t, ls.Names())
+
 	// Load
 	data, err := b.Load(ctx, "foo-1")
 	assert.NoError(t, err)


### PR DESCRIPTION
ListObjects() on the MinIO client returns a channel of minio.ObjectInfo. If a ListObjects operation fails, the channel will contain an ObjectInfo with an error in Err.

This PR adds a test to see if an ObjectInfo has an Err and if so, stops trying to process the object and returns the error.