### PR TITLE
Share name verification accross all backends

### DIFF
--- a/allowedname.go
+++ b/allowedname.go
@@ -1,0 +1,39 @@
+package simpleblob
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var ErrNameNotAllowed = errors.New("name not allowed")
+
+// AllowedName is used to determine if name is suitable to be saved
+// by any backend.
+func AllowedName(name string) bool {
+    	if name == "" {
+        	return false
+    	}
+	if strings.Contains(name, "/") {
+		return false
+	}
+	if strings.Contains(name, "\x00") {
+		return false
+	}
+	if strings.HasPrefix(name, ".") {
+		return false
+	}
+	if strings.HasSuffix(name, ".tmp") {
+		return false // used for our temp files when writing
+	}
+	return true
+}
+
+// CheckName calls AllowedName on name, and if false returns an error
+// wrapping ErrNameNotAllowed.
+func CheckName(name string) error {
+	if AllowedName(name) {
+		return nil
+	}
+	return fmt.Errorf("%q: %w", name, ErrNameNotAllowed)
+}

--- a/allowedname_test.go
+++ b/allowedname_test.go
@@ -1,0 +1,38 @@
+package simpleblob_test
+
+import (
+	"testing"
+
+	"github.com/PowerDNS/simpleblob"
+)
+
+func TestAllowedNames(t *testing.T) {
+	names := []string{
+		"with space",
+		" notrim ",
+		" .not-really-hidden",       // Notice space before '.'
+		"not-really-temporary.tmp ", // Notice space after '.tmp'
+	}
+	for _, name := range names {
+		if !simpleblob.AllowedName(name) {
+			t.Logf("%q: should be allowed", name)
+			t.Fail()
+		}
+	}
+}
+
+func TestForbiddenNames(t *testing.T) {
+	names := []string{
+		".hidden",
+		"temporary.tmp",
+		"has\x00NUL",
+		"has/slash",
+		"",
+	}
+	for _, name := range names {
+		if simpleblob.AllowedName(name) {
+			t.Logf("%q: should be forbidden", name)
+			t.Fail()
+		}
+	}
+}

--- a/backends/memory/memory.go
+++ b/backends/memory/memory.go
@@ -20,6 +20,9 @@ func (b *Backend) List(ctx context.Context, prefix string) (simpleblob.BlobList,
 
 	b.mu.Lock()
 	for name, data := range b.blobs {
+		if !simpleblob.AllowedName(name) {
+			continue
+		}
 		if !strings.HasPrefix(name, prefix) {
 			continue
 		}
@@ -35,6 +38,10 @@ func (b *Backend) List(ctx context.Context, prefix string) (simpleblob.BlobList,
 }
 
 func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
+	if err := simpleblob.CheckName(name); err != nil {
+		return nil, err
+	}
+
 	b.mu.Lock()
 	data, exists := b.blobs[name]
 	b.mu.Unlock()
@@ -48,6 +55,10 @@ func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
 }
 
 func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
+	if err := simpleblob.CheckName(name); err != nil {
+		return err
+	}
+
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
 
@@ -59,6 +70,10 @@ func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
 }
 
 func (b *Backend) Delete(ctx context.Context, name string) error {
+	if err := simpleblob.CheckName(name); err != nil {
+		return err
+	}
+
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	delete(b.blobs, name)

--- a/backends/s3/s3_test.go
+++ b/backends/s3/s3_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
+	"github.com/PowerDNS/simpleblob"
 	"github.com/PowerDNS/simpleblob/tester"
 )
 
@@ -97,7 +98,20 @@ func TestBackend_marker(t *testing.T) {
 	//   i.e. deleting "foo-1"
 
 	// Marker file should have been written accordingly
-	markerFileContent, err := b.Load(ctx, UpdateMarkerFilename)
+	markerFileContent, err := b.doLoad(ctx, UpdateMarkerFilename)
 	assert.NoError(t, err)
 	assert.EqualValues(t, b.lastMarker, markerFileContent)
+
+	// Test that the update marker cannot be loaded, stored,
+	// or deleted.
+	// It must not appear in the blob list either.
+	ls, err := b.List(ctx, UpdateMarkerFilename)
+	assert.Empty(t, ls)
+	assert.NoError(t, err)
+	_, err = b.Load(ctx, UpdateMarkerFilename)
+	assert.ErrorIs(t, err, simpleblob.ErrNameNotAllowed)
+	err = b.Store(ctx, UpdateMarkerFilename, []byte{})
+	assert.ErrorIs(t, err, simpleblob.ErrNameNotAllowed)
+	err = b.Delete(ctx, UpdateMarkerFilename)
+	assert.ErrorIs(t, err, simpleblob.ErrNameNotAllowed)
 }


### PR DESCRIPTION
Provide public functions to make sure we allow the same name across all backends:

```
func AllowedName(name string) bool
func CheckName(name string) error
```