### PR TITLE
S3: GlobalPrefix and Recursive

### DIFF
--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -55,8 +55,9 @@ type Options struct {
 	// seamlessly
 	GlobalPrefix string `yaml:"global_prefix"`
 
-	// Recursive can be enabled to make List operations recurse into nested prefixes
-	Recursive bool `yaml:"recursive"`
+	// PrefixFolders can be enabled to make List operations show nested prefixes as folders
+	// instead of recursively listing all contents of nested prefixes
+	PrefixFolders bool `yaml:"prefix_folders"`
 
 	// EndpointURL can be set to something like "http://localhost:9000" when using Minio
 	// or "https://s3.amazonaws.com" for AWS S3.
@@ -165,7 +166,7 @@ func (b *Backend) doList(ctx context.Context, prefix string) (simpleblob.BlobLis
 
 	objCh := b.client.ListObjects(ctx, b.opt.Bucket, minio.ListObjectsOptions{
 		Prefix:    prefix,
-		Recursive: b.opt.Recursive,
+		Recursive: !b.opt.PrefixFolders,
 	})
 	for obj := range objCh {
 		// Handle error returned by MinIO client

--- a/backends/s3/s3_test.go
+++ b/backends/s3/s3_test.go
@@ -132,24 +132,24 @@ func TestBackend_recursive(t *testing.T) {
 	err = b.Store(ctx, "foo/bar-3", []byte("bar3"))
 	assert.NoError(t, err)
 
-	// List all - no recursion (default)
-	ls, err = b.List(ctx, "")
-	assert.NoError(t, err)
-	assert.Equal(t, ls.Names(), []string{"bar-1", "bar-2", "foo/"})
-
-	// List all - recursive enabled
-	b.opt.Recursive = true
-
+	// List all - PrefixFolders disabled (default)
 	ls, err = b.List(ctx, "")
 	assert.NoError(t, err)
 	assert.Equal(t, ls.Names(), []string{"bar-1", "bar-2", "foo/bar-3"})
 
-	// List all - recursive disabled
-	b.opt.Recursive = false
+	// List all - PrefixFolders enabled
+	b.opt.PrefixFolders = true
 
 	ls, err = b.List(ctx, "")
 	assert.NoError(t, err)
 	assert.Equal(t, ls.Names(), []string{"bar-1", "bar-2", "foo/"})
+
+	// List all - PrefixFolders disabled
+	b.opt.PrefixFolders = false
+
+	ls, err = b.List(ctx, "")
+	assert.NoError(t, err)
+	assert.Equal(t, ls.Names(), []string{"bar-1", "bar-2", "foo/bar-3"})
 
 	assert.Len(t, b.lastMarker, 0)
 }


### PR DESCRIPTION
Adds 2 configuration options to simpleblob, to offer extra control over handling prefixes within a bucket:

- `GlobalPrefix` is a prefix applied to all operations, allowing work within a prefix seamlessly (Default: "" - matches current v0.2.1 behaviour)
- `Recursive` can be enabled to make List operations recurse into nested prefixes (Default: false - matches current v0.2.1 behaviour)

As both default to the current behaviour this does not introduce any breaking changes.

Tests have been updated to cover both options.

**Examples - Recursive**
If a bucket contains the following:
```
- bar1
- bar2
- foo/bar3
- foo/bar4
```

Then a List() using `Recursive` unset or `false` will yield (this is the current v0.2.1 behaviour):
```
- bar1
- bar2
- foo/
```

If `Recursive` is set to `true`, then a List() will yield:
```
- bar1
- bar2
- foo/bar3
- foo/bar4
```

**Examples - GlobalPrefix**
If a bucket contains the following:
```
- bar1
- bar2
- foo/bar3
- foo/bar4
```

Then a List() using `GlobalPrefix` unset or `""` will yield (this is the current v0.2.1 behaviour):
```
- bar1
- bar2
- foo/
```

If `GlobalPrefix` is set to `"foo/"`, then a List() will yield:
```
- bar3
- bar4
```

And a Store() action for name `bar5`, followed by List() will yield:
```
- bar3
- bar4
- bar5
```

The actual contents of the bucket will now be:
```
- bar1
- bar2
- foo/bar3
- foo/bar4
- foo/bar5
```

**Examples - GlobalPrefix & Recursive**
`global_prefix = "foo/"` and `recursive = true` will result in a List() returning:
```
- foo/bar3
- foo/bar4
- foo/bar5
```

`global_prefix = ""` and `recursive = true` will result in a List() returning:
```
- bar1
- bar2
- foo/bar3
- foo/bar4
- foo/bar5
```