### PR TITLE
S3 backend: add missing Close method call for Minio GetObject

### DIFF
--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -212,6 +212,7 @@ func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
 	} else if obj == nil {
 		return nil, os.ErrNotExist
 	}
+	defer obj.Close()
 
 	p, err := io.ReadAll(obj)
 	if err = convertMinioError(err, false); err != nil {


### PR DESCRIPTION
`minio.Object`s have a `Close` method that must be called after use. Without this call, a goroutine stays running in the background, resulting in higher CPU load and several "objects" not being caught by the garbage collector.

This PR fixes memory and CPU loads increasing at each GetObject S3 operation, i.e. when calling `(*Backend).Load` or, when the update marker option is active, `(*Backend).List`.

Closes #44.