### PR TITLE
S3 Backend: load keys from file with automatic reload

### DIFF
--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -25,27 +25,24 @@ type FileSecretsCredentials struct {
 
 // Retrieve implements credentials.Provider.
 // It reads files pointed to by p.AccessKeyFilename and p.SecretKeyFilename.
-func (c *FileSecretsCredentials) Retrieve() (value credentials.Value, err error) {
-	load := func(filename string, dst *string) error {
-		var b []byte
-		b, err = os.ReadFile(filename)
-		if err != nil {
-			return err
-		}
-
-		*dst = string(b)
-		return nil
-	}
-
-	err = load(c.AccessKeyFilename, &value.AccessKeyID)
+func (c *FileSecretsCredentials) Retrieve() (credentials.Value, error) {
+	keyId, err := os.ReadFile(c.AccessKeyFilename)
 	if err != nil {
-		return value, err
+		return credentials.Value{}, err
 	}
-	err = load(c.SecretKeyFilename, &value.SecretAccessKey)
+	secretKey, err := os.ReadFile(c.SecretKeyFilename)
+	if err != nil {
+		return credentials.Value{}, err
+	}
+
+	creds := credentials.Value{
+		AccessKeyID:     string(keyId),
+		SecretAccessKey: string(secretKey),
+	}
 
 	c.SetExpiration(time.Now().Add(time.Second), -1)
 
-	return value, err
+	return creds, err
 }
 
 // IsZero returns true if both c.AccessKeyFilename and c.SecretKeyFilename

--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -1,0 +1,50 @@
+package s3
+
+import (
+	"errors"
+	"os"
+
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// K8sSecretProvider is an implementation of Minio's credentials.Provider,
+// allowing to read credentials from Kubernetes secrets, as described in
+// https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure.
+type K8sSecretProvider struct {
+	// Path to the fiel containing the access key,
+	// e.g. /etc/s3-secrets/access-key.
+	AccessKeyFilename string `json:"access_key_file"`
+
+	// Path to the fiel containing the secret key,
+	// e.g. /etc/s3-secrets/secret-key.
+	SecretKeyFilename string `json:"secret_key_file"`
+}
+
+// IsExpired implements credentials.Provider.
+// As there is no totally reliable way to tell
+// if a file was modified accross all filesystems except opening it,
+// we always return true, and p.Retrieve will open it regardless.
+func (*K8sSecretProvider) IsExpired() bool {
+	return true
+}
+
+// Retrieve implements credentials.Provider.
+// It reads files pointed to by p.AccessKeyFilename and p.SecretKeyFilename.
+func (p *K8sSecretProvider) Retrieve() (value credentials.Value, err error) {
+	load := func(filename string, dst *string) {
+		b, err1 := os.ReadFile(filename)
+		if err1 != nil {
+			err = errors.Join(err, err1)
+			return
+		}
+
+		*dst = string(b)
+	}
+
+	load(p.AccessKeyFilename, &value.AccessKeyID)
+	load(p.SecretKeyFilename, &value.SecretAccessKey)
+
+	return value, err
+}
+
+var _ credentials.Provider = new(K8sSecretProvider)

--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -6,10 +6,11 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
-// K8sSecretProvider is an implementation of Minio's credentials.Provider,
-// allowing to read credentials from Kubernetes secrets, as described in
-// https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure.
-type K8sSecretProvider struct {
+// FileSecretsCredentials is an implementation of Minio's credentials.Provider,
+// allowing to read credentials from Kubernetes or Docker secrets, as described in
+// https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure
+// and https://docs.docker.com/engine/swarm/secrets.
+type FileSecretsCredentials struct {
 	// Path to the fiel containing the access key,
 	// e.g. /etc/s3-secrets/access-key.
 	AccessKeyFilename string `json:"access_key_file"`
@@ -23,13 +24,13 @@ type K8sSecretProvider struct {
 // As there is no totally reliable way to tell
 // if a file was modified accross all filesystems except opening it,
 // we always return true, and p.Retrieve will open it regardless.
-func (*K8sSecretProvider) IsExpired() bool {
+func (*FileSecretsCredentials) IsExpired() bool {
 	return true
 }
 
 // Retrieve implements credentials.Provider.
 // It reads files pointed to by p.AccessKeyFilename and p.SecretKeyFilename.
-func (p *K8sSecretProvider) Retrieve() (value credentials.Value, err error) {
+func (c *FileSecretsCredentials) Retrieve() (value credentials.Value, err error) {
 	load := func(filename string, dst *string) error {
 		var b []byte
 		b, err = os.ReadFile(filename)
@@ -41,13 +42,13 @@ func (p *K8sSecretProvider) Retrieve() (value credentials.Value, err error) {
 		return nil
 	}
 
-	err = load(p.AccessKeyFilename, &value.AccessKeyID)
+	err = load(c.AccessKeyFilename, &value.AccessKeyID)
 	if err != nil {
 		return value, err
 	}
-	err = load(p.SecretKeyFilename, &value.SecretAccessKey)
+	err = load(c.SecretKeyFilename, &value.SecretAccessKey)
 
 	return value, err
 }
 
-var _ credentials.Provider = new(K8sSecretProvider)
+var _ credentials.Provider = new(FileSecretsCredentials)

--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -14,13 +14,13 @@ import (
 type FileSecretsCredentials struct {
 	credentials.Expiry
 
-	// Path to the fiel containing the access key,
+	// Path to the field containing the access key,
 	// e.g. /etc/s3-secrets/access-key.
-	AccessKeyFilename string `json:"access_key_file"`
+	AccessKeyFilename string
 
-	// Path to the fiel containing the secret key,
+	// Path to the field containing the secret key,
 	// e.g. /etc/s3-secrets/secret-key.
-	SecretKeyFilename string `json:"secret_key_file"`
+	SecretKeyFilename string
 }
 
 // Retrieve implements credentials.Provider.
@@ -43,12 +43,6 @@ func (c *FileSecretsCredentials) Retrieve() (credentials.Value, error) {
 	c.SetExpiration(time.Now().Add(time.Second), -1)
 
 	return creds, err
-}
-
-// IsZero returns true if both c.AccessKeyFilename and c.SecretKeyFilename
-// are empty.
-func (c *FileSecretsCredentials) IsZero() bool {
-    	return c.AccessKeyFilename == "" && c.SecretKeyFilename == ""
 }
 
 var _ credentials.Provider = new(FileSecretsCredentials)

--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -14,11 +14,11 @@ import (
 type FileSecretsCredentials struct {
 	credentials.Expiry
 
-	// Path to the field containing the access key,
+	// Path to the file containing the access key,
 	// e.g. /etc/s3-secrets/access-key.
 	AccessKeyFile string
 
-	// Path to the field containing the secret key,
+	// Path to the file containing the secret key,
 	// e.g. /etc/s3-secrets/secret-key.
 	SecretKeyFile string
 }

--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -21,6 +21,9 @@ type FileSecretsCredentials struct {
 	// Path to the file containing the secret key,
 	// e.g. /etc/s3-secrets/secret-key.
 	SecretKeyFile string
+
+	// Time between each secrets retrieval.
+	RefreshInterval time.Duration
 }
 
 // Retrieve implements credentials.Provider.
@@ -40,7 +43,7 @@ func (c *FileSecretsCredentials) Retrieve() (credentials.Value, error) {
 		SecretAccessKey: string(secretKey),
 	}
 
-	c.SetExpiration(time.Now().Add(time.Second), -1)
+	c.SetExpiration(time.Now().Add(c.RefreshInterval), -1)
 
 	return creds, err
 }

--- a/backends/s3/credentials.go
+++ b/backends/s3/credentials.go
@@ -16,21 +16,21 @@ type FileSecretsCredentials struct {
 
 	// Path to the field containing the access key,
 	// e.g. /etc/s3-secrets/access-key.
-	AccessKeyFilename string
+	AccessKeyFile string
 
 	// Path to the field containing the secret key,
 	// e.g. /etc/s3-secrets/secret-key.
-	SecretKeyFilename string
+	SecretKeyFile string
 }
 
 // Retrieve implements credentials.Provider.
 // It reads files pointed to by p.AccessKeyFilename and p.SecretKeyFilename.
 func (c *FileSecretsCredentials) Retrieve() (credentials.Value, error) {
-	keyId, err := os.ReadFile(c.AccessKeyFilename)
+	keyId, err := os.ReadFile(c.AccessKeyFile)
 	if err != nil {
 		return credentials.Value{}, err
 	}
-	secretKey, err := os.ReadFile(c.SecretKeyFilename)
+	secretKey, err := os.ReadFile(c.SecretKeyFile)
 	if err != nil {
 		return credentials.Value{}, err
 	}

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -3,7 +3,6 @@ package s3_test
 import (
 	"context"
 	"errors"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/PowerDNS/simpleblob/backends/s3"
 	"github.com/PowerDNS/simpleblob/backends/s3/s3testing"
+	"github.com/PowerDNS/simpleblob/tester"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
@@ -18,31 +18,12 @@ import (
 func TestFileSecretsCredentials(t *testing.T) {
 	tempDir := t.TempDir()
 
+	access, secret := secretsPaths(tempDir)
+
 	// Instanciate provider (what we're testing).
 	provider := &s3.FileSecretsCredentials{
-		AccessKeyFile: filepath.Join(tempDir, "access-key"),
-		SecretKeyFile: filepath.Join(tempDir, "secret-key"),
-	}
-
-	// writeFiles creates or overwrites provider files
-	// with the same content.
-	writeFiles := func(content string) {
-		writeContent := func(filename string) {
-			f, err := os.Create(filename)
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer f.Close()
-			if content == "" {
-				return
-			}
-			_, err = io.WriteString(f, content)
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-		writeContent(provider.AccessKeyFile)
-		writeContent(provider.SecretKeyFile)
+		AccessKeyFile: access,
+		SecretKeyFile: secret,
 	}
 
 	ctx := context.Background()
@@ -58,11 +39,6 @@ func TestFileSecretsCredentials(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = stop() }()
-
-	// First credential files creation.
-	// Keep them empty for now,
-	// so that calls to the server will fail.
-	writeFiles("")
 
 	// Create minio client, using our provider.
 	creds := credentials.New(provider)
@@ -86,6 +62,11 @@ func TestFileSecretsCredentials(t *testing.T) {
 		}
 	}
 
+	// First credential files creation.
+	// Keep them empty for now,
+	// so that calls to the server will fail.
+	writeSecrets(t, tempDir, "")
+
 	// The files do not hold the right values,
 	// so a call to the server should fail.
 	assertClientSuccess(false, "just after init")
@@ -93,12 +74,94 @@ func TestFileSecretsCredentials(t *testing.T) {
 	// Write the right keys to the files.
 	// We're not testing expiry here,
 	// and forcing credentials cache to update.
-	writeFiles(s3testing.AdminUserOrPassword)
+	writeSecrets(t, tempDir, s3testing.AdminUserOrPassword)
 	creds.Expire()
 	assertClientSuccess(true, "after changing files content")
 
 	// Change content of the files.
-	writeFiles("badcredentials")
+	writeSecrets(t, tempDir, "badcredentials")
 	creds.Expire()
 	assertClientSuccess(false, "after changing again, to bad credentials")
+}
+
+func TestBackendWithSecrets(t *testing.T) {
+	tempDir := t.TempDir()
+
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	addr, stop, err := s3testing.ServeMinio(ctx, tempDir)
+	if errors.Is(err, s3testing.ErrMinioNotFound) {
+		t.Skip("minio binary not found locally, make sure it is in PATH")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = stop() }()
+
+	// Prepare backend options to reuse.
+	// These will not change.
+	access, secret := secretsPaths(tempDir)
+	opt := s3.Options{
+		AccessKeyFile: access,
+		SecretKeyFile: secret,
+		Region:        "us-east-1",
+		Bucket:        "test-bucket",
+		CreateBucket:  true,
+		EndpointURL:   "http://" + addr,
+	}
+
+	// Backend should not start if secrets files do not exist.
+	_, err = s3.New(ctx, opt)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("backend should not start without credentials")
+	}
+
+	// Now write files, but with bad content.
+	writeSecrets(t, tempDir, "")
+	_, err = s3.New(ctx, opt)
+	if err == nil || err.Error() != "Access Denied." {
+		t.Fatal("backend should not start with bad credentials")
+	}
+
+	// Write the good content.
+	// Now the backend should start and be able to perform a request.
+	writeSecrets(t, tempDir, s3testing.AdminUserOrPassword)
+
+	backend, err := s3.New(ctx, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = backend.List(ctx, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Finally, the whole test suite should succeed.
+	tester.DoBackendTests(t, backend)
+}
+
+// secretsPaths returns the file paths for the access key
+// and the secret key, respectively.
+// For a same dir, the returned values will always be the same.
+func secretsPaths(dir string) (access, secret string) {
+	access = filepath.Join(dir, "access-key")
+	secret = filepath.Join(dir, "secret-key")
+	return
+}
+
+// writeSecrets writes content to files called "access-key" and "secret-key"
+// in dir.
+// It returns
+func writeSecrets(t testing.TB, dir, content string) {
+	access, secret := secretsPaths(dir)
+	err := os.WriteFile(access, []byte(content), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(secret, []byte(content), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
 }

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -55,7 +55,7 @@ func TestPodProvider(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer stop()
+	defer func() { _ = stop() }()
 
 	// First credential files creation.
 	// Keep them empty for now,

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/PowerDNS/simpleblob/backends/s3"
@@ -17,12 +18,12 @@ func TestPodProvider(t *testing.T) {
 		t.Skip("Skipping test requiring downloading minio")
 	}
 
-	_ = os.Chdir(t.TempDir())
+	tempDir := t.TempDir()
 
 	// Instanciate provider (what we're testing).
 	provider := &s3.FileSecretsCredentials{
-		AccessKeyFilename: "access-key",
-		SecretKeyFilename: "secret-key",
+		AccessKeyFilename: filepath.Join(tempDir, "access-key"),
+		SecretKeyFilename: filepath.Join(tempDir, "secret-key"),
 	}
 
 	// writeFiles creates or overwrites provider files
@@ -51,7 +52,7 @@ func TestPodProvider(t *testing.T) {
 	defer cancel()
 
 	// Create server
-	addr, stop, err := s3testing.ServeMinio(ctx, ".")
+	addr, stop, err := s3testing.ServeMinio(ctx, tempDir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -20,7 +20,7 @@ func TestPodProvider(t *testing.T) {
 	_ = os.Chdir(t.TempDir())
 
 	// Instanciate provider (what we're testing).
-	provider := &s3.K8sSecretProvider{
+	provider := &s3.FileSecretsCredentials{
 		AccessKeyFilename: "access-key",
 		SecretKeyFilename: "secret-key",
 	}

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -19,8 +19,8 @@ func TestFileSecretsCredentials(t *testing.T) {
 
 	// Instanciate provider (what we're testing).
 	provider := &s3.FileSecretsCredentials{
-		AccessKeyFilename: filepath.Join(tempDir, "access-key"),
-		SecretKeyFilename: filepath.Join(tempDir, "secret-key"),
+		AccessKeyFile: filepath.Join(tempDir, "access-key"),
+		SecretKeyFile: filepath.Join(tempDir, "secret-key"),
 	}
 
 	// writeFiles creates or overwrites provider files
@@ -40,8 +40,8 @@ func TestFileSecretsCredentials(t *testing.T) {
 				t.Fatal(err)
 			}
 		}
-		writeContent(provider.AccessKeyFilename)
-		writeContent(provider.SecretKeyFilename)
+		writeContent(provider.AccessKeyFile)
+		writeContent(provider.SecretKeyFile)
 	}
 
 	ctx := context.Background()

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -1,0 +1,98 @@
+package s3_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/PowerDNS/simpleblob/backends/s3"
+	"github.com/PowerDNS/simpleblob/backends/s3/s3testing"
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+func TestPodProvider(t *testing.T) {
+	if testing.Short() && !s3testing.HasLocalMinio() {
+		t.Skip("Skipping test requiring downloading minio")
+	}
+
+	_ = os.Chdir(t.TempDir())
+
+	// Instanciate provider (what we're testing).
+	provider := &s3.K8sSecretProvider{
+		AccessKeyFilename: "access-key",
+		SecretKeyFilename: "secret-key",
+	}
+
+	// writeFiles creates or overwrites provider files
+	// with the same content.
+	writeFiles := func(content string) {
+		writeContent := func(filename string) {
+			f, err := os.Create(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer f.Close()
+			if content == "" {
+				return
+			}
+			_, err = io.WriteString(f, content)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		writeContent(provider.AccessKeyFilename)
+		writeContent(provider.SecretKeyFilename)
+	}
+
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Create server
+	addr, stop, err := s3testing.ServeMinio(ctx, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stop()
+
+	// First credential files creation.
+	// Keep them empty for now,
+	// so that calls to the server will fail.
+	writeFiles("")
+
+	// Create minio client, using our provider.
+	creds := credentials.New(provider)
+	clt, err := minio.New(addr, &minio.Options{
+		Creds:  creds,
+		Region: "us-east-1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assertClientSuccess := func(want bool, when string) {
+		_, err = clt.BucketExists(ctx, "doesnotmatter")
+		s := "fail"
+		if want {
+			s = "succeed"
+		}
+		ok := (err == nil) == want
+		if !ok {
+			t.Fatalf("expected call to %s %s", s, when)
+		}
+	}
+
+	// The files do not hold the right values,
+	// so a call to the server should fail.
+	assertClientSuccess(false, "just after init")
+
+	// Write the right keys to the files.
+	writeFiles(s3testing.AdminUserOrPassword)
+	assertClientSuccess(true, "after changing files content")
+
+	// Change content of the files.
+	writeFiles("badcredentials")
+	assertClientSuccess(false, "after changing again, to bad credentials")
+}

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -89,10 +89,14 @@ func TestPodProvider(t *testing.T) {
 	assertClientSuccess(false, "just after init")
 
 	// Write the right keys to the files.
+	// We're not testing expiry here,
+	// and forcing credentials cache to update.
 	writeFiles(s3testing.AdminUserOrPassword)
+	creds.Expire()
 	assertClientSuccess(true, "after changing files content")
 
 	// Change content of the files.
 	writeFiles("badcredentials")
+	creds.Expire()
 	assertClientSuccess(false, "after changing again, to bad credentials")
 }

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -2,6 +2,7 @@ package s3_test
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -14,10 +15,6 @@ import (
 )
 
 func TestPodProvider(t *testing.T) {
-	if testing.Short() && !s3testing.HasLocalMinio() {
-		t.Skip("Skipping test requiring downloading minio")
-	}
-
 	tempDir := t.TempDir()
 
 	// Instanciate provider (what we're testing).
@@ -53,6 +50,9 @@ func TestPodProvider(t *testing.T) {
 
 	// Create server
 	addr, stop, err := s3testing.ServeMinio(ctx, tempDir)
+	if errors.Is(err, s3testing.ErrMinioNotFound) {
+		t.Skip("minio binary not found locally, make sure it is in PATH")
+	}
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/PowerDNS/simpleblob/backends/s3"
 	"github.com/PowerDNS/simpleblob/backends/s3/s3testing"
@@ -45,7 +46,7 @@ func TestFileSecretsCredentials(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx, cancel := context.WithCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	// Create server

--- a/backends/s3/credentials_test.go
+++ b/backends/s3/credentials_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
-func TestPodProvider(t *testing.T) {
+func TestFileSecretsCredentials(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Instanciate provider (what we're testing).

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -46,7 +46,7 @@ type Options struct {
 	SecretKey string `yaml:"secret_key"`
 
 	// Allow using custom credentials provider.
-	Provider K8sSecretProvider `yaml:"kubernetes_secrets,omitempty"`
+	Provider FileSecretsCredentials `yaml:"kubernetes_secrets,omitempty"`
 
 	// Region defaults to "us-east-1", which also works for Minio
 	Region string `yaml:"region"`
@@ -96,7 +96,7 @@ type Options struct {
 }
 
 func (o Options) Check() error {
-	hasProvider := o.Provider != K8sSecretProvider{}
+	hasProvider := o.Provider != FileSecretsCredentials{}
 	if !hasProvider && o.AccessKey == "" {
 		return fmt.Errorf("s3 storage.options: access_key is required")
 	}
@@ -347,7 +347,7 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	}
 
 	creds := credentials.NewStaticV4(opt.AccessKey, opt.SecretKey, "")
-	if opt.Provider != (K8sSecretProvider{}) {
+	if opt.Provider != (FileSecretsCredentials{}) {
 		creds = credentials.New(&opt.Provider)
 	}
 

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -45,13 +45,15 @@ type Options struct {
 	AccessKey string `yaml:"access_key"`
 	SecretKey string `yaml:"secret_key"`
 
-	// Path to the field containing the access key,
+	// Path to the file containing the access key
+	// as an alternative to AccessKey and SecretKey,
 	// e.g. /etc/s3-secrets/access-key.
-	AccessKeyFilename string `json:"access_key_filename"`
+	AccessKeyFile string `yaml:"access_key_file"`
 
-	// Path to the field containing the secret key,
+	// Path to the field containing the secret key
+	// as an alternative to AccessKey and SecretKey,
 	// e.g. /etc/s3-secrets/secret-key.
-	SecretKeyFilename string `json:"secret_key_filename"`
+	SecretKeyFile string `yaml:"secret_key_file"`
 
 	// Region defaults to "us-east-1", which also works for Minio
 	Region string `yaml:"region"`
@@ -101,7 +103,7 @@ type Options struct {
 }
 
 func (o Options) Check() error {
-	hasSecretsCreds := o.AccessKeyFilename != "" && o.SecretKeyFilename != ""
+	hasSecretsCreds := o.AccessKeyFile != "" && o.SecretKeyFile != ""
 	hasStaticCreds := o.AccessKey != "" && o.SecretKey != ""
 	if !hasSecretsCreds && !hasStaticCreds {
 		return fmt.Errorf("s3 storage.options: credentials are required, fill either (access_key and secret_key) or (access_key_filename and secret_key_filename)")
@@ -350,10 +352,10 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	}
 
 	creds := credentials.NewStaticV4(opt.AccessKey, opt.SecretKey, "")
-	if opt.AccessKeyFilename != "" {
+	if opt.AccessKeyFile != "" {
 		creds = credentials.New(&FileSecretsCredentials{
-			AccessKeyFilename: opt.AccessKeyFilename,
-			SecretKeyFilename: opt.SecretKeyFilename,
+			AccessKeyFile: opt.AccessKeyFile,
+			SecretKeyFile: opt.SecretKeyFile,
 		})
 	}
 

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -96,7 +96,7 @@ type Options struct {
 }
 
 func (o Options) Check() error {
-	hasProvider := o.Provider != FileSecretsCredentials{}
+	hasProvider := !o.Provider.IsZero()
 	if !hasProvider && o.AccessKey == "" {
 		return fmt.Errorf("s3 storage.options: access_key is required")
 	}
@@ -347,7 +347,7 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	}
 
 	creds := credentials.NewStaticV4(opt.AccessKey, opt.SecretKey, "")
-	if opt.Provider != (FileSecretsCredentials{}) {
+	if !opt.Provider.IsZero() {
 		creds = credentials.New(&opt.Provider)
 	}
 

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -117,7 +117,7 @@ func (o Options) Check() error {
 	if !hasSecretsCreds && !hasStaticCreds {
 		return fmt.Errorf("s3 storage.options: credentials are required, fill either (access_key and secret_key) or (access_key_filename and secret_key_filename)")
 	}
-	if d := o.SecretsRefreshInterval; hasSecretsCreds && d != 0 && d < time.Second {
+	if hasSecretsCreds && o.SecretsRefreshInterval < time.Second {
 		return fmt.Errorf("s3 storage.options: field refresh_secrets is required when using secret credentials")
 	}
 	if o.Bucket == "" {

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -118,7 +118,7 @@ func (o Options) Check() error {
 		return fmt.Errorf("s3 storage.options: credentials are required, fill either (access_key and secret_key) or (access_key_filename and secret_key_filename)")
 	}
 	if hasSecretsCreds && o.SecretsRefreshInterval < time.Second {
-		return fmt.Errorf("s3 storage.options: field refresh_secrets is required when using secret credentials")
+		return fmt.Errorf("s3 storage.options: field secrets_refresh_interval must be at least 1s")
 	}
 	if o.Bucket == "" {
 		return fmt.Errorf("s3 storage.options: bucket is required")

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -50,7 +50,7 @@ type Options struct {
 	// e.g. /etc/s3-secrets/access-key.
 	AccessKeyFile string `yaml:"access_key_file"`
 
-	// Path to the field containing the secret key
+	// Path to the file containing the secret key
 	// as an alternative to AccessKey and SecretKey,
 	// e.g. /etc/s3-secrets/secret-key.
 	SecretKeyFile string `yaml:"secret_key_file"`

--- a/backends/s3/s3testing/minio.go
+++ b/backends/s3/s3testing/minio.go
@@ -48,6 +48,8 @@ func ServeMinio(ctx context.Context, dir string) (string, func() error, error) {
 
 	// Wait for server to accept requests.
 	readyURL := "http://" + addr + "/minio/health/ready"
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	ticker := time.NewTicker(30 * time.Millisecond)
 	defer ticker.Stop()
 	for {

--- a/backends/s3/s3testing/minio.go
+++ b/backends/s3/s3testing/minio.go
@@ -38,7 +38,7 @@ func ServeMinio(ctx context.Context, dir string) (string, func() error, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, cmdname, "server", "--quiet", "--address", addr, dir)
-	cmd.Env = append(cmd.Environ(), "MINIO_BROWSER=off")
+	cmd.Env = append(os.Environ(), "MINIO_BROWSER=off")
 	cmd.Env = append(cmd.Env, "MINIO_ROOT_USER="+AdminUserOrPassword, "MINIO_ROOT_PASSWORD="+AdminUserOrPassword)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/backends/s3/s3testing/minio.go
+++ b/backends/s3/s3testing/minio.go
@@ -2,19 +2,18 @@ package s3testing
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
-	"runtime"
 	"time"
 )
 
 const (
 	AdminUserOrPassword = "simpleblob"
 )
+
+var ErrMinioNotFound = exec.ErrNotFound
 
 // ServeMinio starts a Minio server in the background,
 // and waits for it to be ready.
@@ -23,19 +22,19 @@ const (
 //
 // The admin username and password for the server are both "simpleblob".
 //
-// If the minio binary cannot be found locally,
-// it is downloaded by calling MinioBin.
+// If the minio binary cannot be found in PATH,
+// ErrMinioNotFound will be returned.
 func ServeMinio(ctx context.Context, dir string) (string, func() error, error) {
+	cmdname, err := exec.LookPath("minio")
+	if err != nil {
+		return "", nil, err
+	}
+
 	port, err := FreePort()
 	if err != nil {
 		return "", nil, err
 	}
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-
-	cmdname, err := MinioBin()
-	if err != nil {
-		return "", nil, err
-	}
 
 	cmd := exec.CommandContext(ctx, cmdname, "server", "--quiet", "--address", addr, dir)
 	cmd.Env = append(os.Environ(), "MINIO_BROWSER=off")
@@ -68,64 +67,4 @@ func ServeMinio(ctx context.Context, dir string) (string, func() error, error) {
 		return cmd.Wait()
 	}
 	return addr, stop, nil
-}
-
-// minioExecPath is the cached path to minio binary,
-// that is returned when calling MinioBin.
-var minioExecPath string
-
-// HasLocalMinio returns true if minio can be found in PATH.
-// If an error occurs while searching,
-// the function panics.
-func HasLocalMinio() bool {
-	_, err := exec.LookPath("minio")
-	if err != nil && !errors.Is(err, exec.ErrNotFound) {
-		panic(err)
-	}
-	return err == nil
-}
-
-// MinioBin tries to find minio in PATH,
-// or downloads it to a temporary file.
-//
-// The result is cached and shared among callers.
-func MinioBin() (string, error) {
-	if minioExecPath != "" {
-		return minioExecPath, nil
-	}
-
-	binpath, err := exec.LookPath("minio")
-	if err == nil {
-		minioExecPath = binpath
-		return binpath, nil
-	}
-	if !errors.Is(err, exec.ErrNotFound) {
-		return "", err
-	}
-
-	f, err := os.CreateTemp("", "minio")
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	url := fmt.Sprintf("https://dl.min.io/server/minio/release/%s-%s/minio", runtime.GOOS, runtime.GOARCH)
-	resp, err := http.Get(url)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	_, err = io.Copy(f, resp.Body)
-	if err != nil {
-		return "", err
-	}
-
-	err = f.Chmod(0755)
-	if err != nil {
-		return "", err
-	}
-
-	minioExecPath = f.Name()
-	return minioExecPath, nil
 }

--- a/backends/s3/s3testing/minio.go
+++ b/backends/s3/s3testing/minio.go
@@ -1,0 +1,131 @@
+package s3testing
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+const (
+	AdminUserOrPassword = "simpleblob"
+)
+
+// ServeMinio starts a Minio server in the background,
+// and waits for it to be ready.
+// It returns its address,
+// and a function to stop the server gracefully.
+//
+// The admin username and password for the server are both "simpleblob".
+//
+// If the minio binary cannot be found locally,
+// it is downloaded by calling MinioBin.
+func ServeMinio(ctx context.Context, dir string) (string, func() error, error) {
+	port, err := FreePort()
+	if err != nil {
+		return "", nil, err
+	}
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	cmdname, err := MinioBin()
+	if err != nil {
+		return "", nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, cmdname, "server", "--quiet", "--address", addr, dir)
+	cmd.Env = append(cmd.Environ(), "MINIO_BROWSER=off")
+	cmd.Env = append(cmd.Env, "MINIO_ROOT_USER="+AdminUserOrPassword, "MINIO_ROOT_PASSWORD="+AdminUserOrPassword)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return "", nil, err
+	}
+
+	// Wait for server to accept requests.
+	readyURL := "http://" + addr + "/minio/health/ready"
+	ticker := time.NewTicker(30 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", nil, ctx.Err()
+		case <-ticker.C:
+		}
+
+		resp, err := http.Get(readyURL)
+		if err == nil && resp.StatusCode == 200 {
+			break
+		}
+	}
+
+	stop := func() error {
+		_ = cmd.Process.Signal(os.Interrupt)
+		return cmd.Wait()
+	}
+	return addr, stop, nil
+}
+
+// minioExecPath is the cached path to minio binary,
+// that is returned when calling MinioBin.
+var minioExecPath string
+
+// HasLocalMinio returns true if minio can be found in PATH.
+// If an error occurs while searching,
+// the function panics.
+func HasLocalMinio() bool {
+	_, err := exec.LookPath("minio")
+	if err != nil && !errors.Is(err, exec.ErrNotFound) {
+		panic(err)
+	}
+	return err == nil
+}
+
+// MinioBin tries to find minio in PATH,
+// or downloads it to a temporary file.
+//
+// The result is cached and shared among callers.
+func MinioBin() (string, error) {
+	if minioExecPath != "" {
+		return minioExecPath, nil
+	}
+
+	binpath, err := exec.LookPath("minio")
+	if err == nil {
+		minioExecPath = binpath
+		return binpath, nil
+	}
+	if !errors.Is(err, exec.ErrNotFound) {
+		return "", err
+	}
+
+	f, err := os.CreateTemp("", "minio")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	url := fmt.Sprintf("https://dl.min.io/server/minio/release/%s-%s/minio", runtime.GOOS, runtime.GOARCH)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(f, resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	err = f.Chmod(0755)
+	if err != nil {
+		return "", err
+	}
+
+	minioExecPath = f.Name()
+	return minioExecPath, nil
+}

--- a/backends/s3/s3testing/minio.go
+++ b/backends/s3/s3testing/minio.go
@@ -37,7 +37,8 @@ func ServeMinio(ctx context.Context, dir string) (string, func() error, error) {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 
 	cmd := exec.CommandContext(ctx, cmdname, "server", "--quiet", "--address", addr, dir)
-	cmd.Env = append(os.Environ(), "MINIO_BROWSER=off")
+	cmd.Env = append([]string{}, os.Environ()...)
+	cmd.Env = append(cmd.Env, "MINIO_BROWSER=off")
 	cmd.Env = append(cmd.Env, "MINIO_ROOT_USER="+AdminUserOrPassword, "MINIO_ROOT_PASSWORD="+AdminUserOrPassword)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/backends/s3/s3testing/port.go
+++ b/backends/s3/s3testing/port.go
@@ -1,0 +1,14 @@
+package s3testing
+
+import "net"
+
+// FreePort returns a port number free for use.
+func FreePort() (int, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	addr := l.Addr().(*net.TCPAddr)
+	return addr.Port, nil
+}


### PR DESCRIPTION
Introduce a [`github.com/minio/minio-go/v7/pkg/credentials.Provider`](https://pkg.go.dev/github.com/minio/minio-go/v7/pkg/credentials#hdr-Custom_Provider) implementation, accepting credentials split accross different files as with [Kubernetes Secrets](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure) or [Docker Secrets](https://docs.docker.com/engine/swarm/secrets).

This way, the backend can get its S3 credentials with a configuration similar to:

```json
{
  "access_key_file": "/etc/secret-volume/access-key",
  "secret_key_file": "/etc/secret-volume/secret-key"
}
```