### PR TITLE
S3: deprecate PrefixFolders and introduce HideFolders

### DIFF
--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -217,7 +217,7 @@ func (b *Backend) doList(ctx context.Context, prefix string) (simpleblob.BlobLis
 			continue
 		}
 
-		if b.opt.HideFolders && strings.Contains(obj.Key, "/") {
+		if b.opt.HideFolders && strings.HasSuffix(obj.Key, "/") {
 			continue
 		}
 

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -85,6 +85,13 @@ type Options struct {
 
 	// HideFolders is an S3-specific optimization, allowing to hide all keys that
 	// have a separator '/' in their names.
+	// In case a prefix representing a folder is provided to List,
+	// that folder will be explored, and its subfolders hidden.
+	//
+	// Moreover, please note that regardless of this option,
+	// working with folders with S3 is flaky,
+	// because a `foo` key will shadow all `foo/*` keys while listing,
+	// even though those `foo/*` keys exist and they hold the values they're expected to.
 	HideFolders bool `yaml:"hide_folders"`
 
 	// EndpointURL can be set to something like "http://localhost:9000" when using Minio

--- a/backends/s3/s3_test.go
+++ b/backends/s3/s3_test.go
@@ -127,6 +127,8 @@ func TestBackend_globalPrefixAndMarker(t *testing.T) {
 }
 
 func TestBackend_recursive(t *testing.T) {
+    	// NB: Those tests are for PrefixFolders, a deprecated options.
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -163,6 +165,12 @@ func TestBackend_recursive(t *testing.T) {
 	ls, err = b.List(ctx, "")
 	assert.NoError(t, err)
 	assert.Equal(t, ls.Names(), []string{"bar-1", "bar-2", "foo/bar-3"})
+
+	// List all - HideFolders enabled
+	b.opt.HideFolders = true
+	ls, err = b.List(ctx, "")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"bar-1", "bar-2"}, ls.Names())
 
 	assert.Len(t, b.lastMarker, 0)
 }


### PR DESCRIPTION
The `PrefixFolders` option has a behaviour that is confusing and does not allow listing the way other backends do.
This PR deprecates `PrefixFolders` and introduces another option that helps work with folders in S3: `HideFolders`.

Its effect is pretty close to that of `PrefixFolder`, except that instead of just showing folders names without their content as `folder/`, it will ignore them.

```go
// Example:

s3backend.Store(ctx, "foo", something)
s3backend.Store(ctx, "bar/baz", anything)

// Without HideFolders:
s3backend.List(ctx, "") // "foo", "bar/baz"

// With HideFolders:
s3backend.List(ctx, "") // "foo"
s3backend.List(ctx, "bar/") // "bar/baz"
```