### PR TITLE
Size function for BlobList

### DIFF
--- a/blobs.go
+++ b/blobs.go
@@ -45,3 +45,12 @@ func (bl BlobList) WithPrefix(prefix string) (blobs BlobList) {
 	}
 	return blobs
 }
+
+// Size returns the total size of all blobs in the BlobList
+func (bl BlobList) Size() int64 {
+	var size int64
+	for _, b := range bl {
+		size += b.Size
+	}
+	return size
+}

--- a/blobs_test.go
+++ b/blobs_test.go
@@ -1,0 +1,25 @@
+package simpleblob
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlobListStats(t *testing.T) {
+	// Empty BlobList
+	var blobs BlobList
+	assert.Equal(t, blobs.Len(), 0)
+	assert.Equal(t, blobs.Size(), int64(0))
+
+	// Non-empty BlobList
+	blobs = append(blobs, Blob{
+		Name: "blob1",
+		Size: 100,
+	}, Blob{
+		Name: "blob2",
+		Size: 200,
+	})
+	assert.Equal(t, blobs.Len(), 2)
+	assert.Equal(t, blobs.Size(), int64(300))
+}


### PR DESCRIPTION
Description:
PR adds a `Size()` function to `BlobList`

Motivation: 
Allows projects which use Simpleblob to access the total size of all blobs in a BlobList (in my case to store the total size of a specific BlobList as a metric in Prometheus for monitoring purposes)

Includes a basic test to ensure the size is correct (also for the existing `Len()` as this can be tested using the same data)