### PR TITLE
`fs`, `memory`, `s3` marker: take context cancellation into account

### DIFF
--- a/backends/fs/fs.go
+++ b/backends/fs/fs.go
@@ -22,6 +22,9 @@ type Backend struct {
 
 func (b *Backend) List(ctx context.Context, prefix string) (simpleblob.BlobList, error) {
 	var blobs simpleblob.BlobList
+	if err := ctx.Err(); err != nil {
+		return blobs, err
+	}
 
 	entries, err := os.ReadDir(b.rootPath)
 	if err != nil {
@@ -59,6 +62,9 @@ func (b *Backend) List(ctx context.Context, prefix string) (simpleblob.BlobList,
 }
 
 func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if !allowedName(name) {
 		return nil, os.ErrNotExist
 	}
@@ -67,6 +73,9 @@ func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
 }
 
 func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if !allowedName(name) {
 		return os.ErrPermission
 	}
@@ -82,6 +91,9 @@ func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
 }
 
 func (b *Backend) Delete(ctx context.Context, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if !allowedName(name) {
 		return os.ErrPermission
 	}
@@ -119,6 +131,9 @@ func New(opt Options) (*Backend, error) {
 
 func init() {
 	simpleblob.RegisterBackend("fs", func(ctx context.Context, p simpleblob.InitParams) (simpleblob.Interface, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		var opt Options
 		if err := p.OptionsThroughYAML(&opt); err != nil {
 			return nil, err

--- a/backends/memory/memory.go
+++ b/backends/memory/memory.go
@@ -17,6 +17,9 @@ type Backend struct {
 
 func (b *Backend) List(ctx context.Context, prefix string) (simpleblob.BlobList, error) {
 	var blobs simpleblob.BlobList
+	if err := ctx.Err(); err != nil {
+		return blobs, err
+	}
 
 	b.mu.Lock()
 	for name, data := range b.blobs {
@@ -35,6 +38,9 @@ func (b *Backend) List(ctx context.Context, prefix string) (simpleblob.BlobList,
 }
 
 func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	b.mu.Lock()
 	data, exists := b.blobs[name]
 	b.mu.Unlock()
@@ -48,6 +54,9 @@ func (b *Backend) Load(ctx context.Context, name string) ([]byte, error) {
 }
 
 func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	dataCopy := make([]byte, len(data))
 	copy(dataCopy, data)
 
@@ -59,6 +68,9 @@ func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
 }
 
 func (b *Backend) Delete(ctx context.Context, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	delete(b.blobs, name)
@@ -71,6 +83,9 @@ func New() *Backend {
 
 func init() {
 	simpleblob.RegisterBackend("memory", func(ctx context.Context, p simpleblob.InitParams) (simpleblob.Interface, error) {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		return New(), nil
 	})
 }

--- a/backends/s3/marker.go
+++ b/backends/s3/marker.go
@@ -14,7 +14,7 @@ import (
 // anything and returns no error.
 func (b *Backend) setMarker(ctx context.Context, name, etag string, isDel bool) error {
 	if !b.opt.UseUpdateMarker {
-		return nil
+		return ctx.Err()
 	}
 	nanos := time.Now().UnixNano()
 	s := fmt.Sprintf("%s:%s:%d:%v", name, etag, nanos, isDel)

--- a/tester/tester.go
+++ b/tester/tester.go
@@ -95,4 +95,16 @@ func DoBackendTests(t *testing.T, b simpleblob.Interface) {
 	ls, err = b.List(ctx, "")
 	assert.NoError(t, err)
 	assert.NotContains(t, ls.Names(), "foo-1")
+
+	// Should gracefully accept context cancellation.
+	ctx1, cancel1 := context.WithCancel(ctx)
+	cancel1()
+	_, err = b.List(ctx1, "")
+	assert.ErrorIs(t, err, context.Canceled)
+	_, err = b.Load(ctx1, "anything")
+	assert.ErrorIs(t, err, context.Canceled)
+	err = b.Delete(ctx1, "anything")
+	assert.ErrorIs(t, err, context.Canceled)
+	err = b.Store(ctx1, "anything", []byte{})
+	assert.ErrorIs(t, err, context.Canceled)
 }


### PR DESCRIPTION
All function for backends `fs` and `memory` do not use their `ctx` parameter. This adds checks for `ctx.Err()` at the beginning of those.

As for `s3`, check `ctx` from marker logic even if marker is disabled.