### PR TITLE
S3 Stream Writer: simpler and more robust logic

### DIFF
--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -46,7 +46,7 @@ type writerWrapper struct {
 }
 
 // Write sends p to store as the S3 object associated with w.
-// An error is returned if Write failed previously, an error occured on the S3 side, or w is already closed.
+// An error is returned if Write failed previously, an error occured in S3, or w is already closed.
 func (w *writerWrapper) Write(p []byte) (n int, err error) {
 	// Not checking the status of ctx explicitly because it will be propagated
 	// from the reader goroutine.
@@ -55,13 +55,13 @@ func (w *writerWrapper) Write(p []byte) (n int, err error) {
 }
 
 // Close ensures that the written data is saved.
-// An error is returned if Write failed previously, an error occured on the S3 side, or w is already closed.
+// An error is returned if Write failed previously, an error occured in S3, or w is already closed.
 func (w *writerWrapper) Close() (err error) {
 	err = w.prevErr
 	_ = w.pw.CloseWithError(err)
 	if w.prevErr == nil {
 		w.prevErr = simpleblob.ErrClosed
 	}
-	<-w.ctx.Done()
+	<-w.ctx.Done() // cancelled after writing the marker
 	return err
 }

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"io"
+	"sync"
 )
 
 // NewReader satisfies StreamReader and provides a read streaming interface to
@@ -19,26 +20,24 @@ func (b *Backend) NewReader(ctx context.Context, name string) (io.ReadCloser, er
 // NewWriter satisfies StreamWriter and provides a write streaming interface to
 // a blob located on an S3 server.
 func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, error) {
-	ctx, cancel := context.WithCancel(ctx)
 	name = b.prependGlobalPrefix(name)
 	pr, pw := io.Pipe()
-	go func(ctx context.Context, b *Backend, name string, pr *io.PipeReader, cancel context.CancelFunc) {
+	w := &writerWrapper{pw: pw}
+	w.wg.Go(func() {
 		// This call returns when the pipe is closed, or when an error occurs.
 		info, err := b.doStoreReader(ctx, name, pr, -1)
 		if err == nil {
 			_ = b.setMarker(ctx, name, info.ETag, false)
 		}
 		_ = pr.CloseWithError(err)
-		cancel()
-	}(ctx, b, name, pr, cancel)
-	return &writerWrapper{backend: b, ctx: ctx, pw: pw}, nil
+	})
+	return w, nil
 }
 
 // A writerWrapper allows storing data on S3 through a io.WriteCloser.
 type writerWrapper struct {
-	backend *Backend
-	ctx     context.Context
-	pw      *io.PipeWriter
+	wg sync.WaitGroup
+	pw *io.PipeWriter
 }
 
 // Write sends p to store as the S3 object associated with w.
@@ -56,6 +55,6 @@ func (w *writerWrapper) Close() error {
 	_ = w.pw.Close()
 	// Let the reading goroutine finish writing,
 	// and write the marker if needed.
-	<-w.ctx.Done() // cancelled after writing the marker
+	w.wg.Wait()
 	return err
 }

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -46,11 +46,14 @@ type writerWrapper struct {
 
 // Write sends p to store as the S3 object associated with w.
 // An error is returned if Write failed previously, an error occurred in S3, or w is already closed.
-func (w *writerWrapper) Write(p []byte) (n int, err error) {
+func (w *writerWrapper) Write(p []byte) (int, error) {
 	// Not checking the status of ctx explicitly because it will be propagated
 	// from the reader goroutine.
-	n, w.prevErr = w.pw.Write(p)
-	return n, w.prevErr
+	n, err := w.pw.Write(p)
+	if w.prevErr == nil && err != nil {
+		w.prevErr = err
+	}
+	return n, err
 }
 
 // Close ensures that the written data is saved.

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -22,7 +22,7 @@ func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, e
 	ctx, cancel := context.WithCancel(ctx)
 	name = b.prependGlobalPrefix(name)
 	pr, pw := io.Pipe()
-	go func(ctx context.Context, b *Backend, name string, pr *io.PipeReader, cancel context.CancelFunc) {
+	go func() {
 		// This call returns when the pipe is closed, or when an error occurs.
 		info, err := b.doStoreReader(ctx, name, pr, -1)
 		if err == nil {
@@ -30,7 +30,7 @@ func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, e
 		}
 		_ = pr.CloseWithError(err)
 		cancel()
-	}(ctx, b, name, pr, cancel)
+	}()
 	return &writerWrapper{ctx: ctx, pw: pw}, nil
 }
 

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -49,8 +49,11 @@ type writerWrapper struct {
 func (w *writerWrapper) Write(p []byte) (int, error) {
 	// Not checking the status of ctx explicitly because it will be propagated
 	// from the reader goroutine.
+	if w.prevErr != nil {
+		return 0, w.prevErr
+	}
 	n, err := w.pw.Write(p)
-	if w.prevErr == nil && err != nil {
+	if err != nil {
 		w.prevErr = err
 	}
 	return n, err

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -28,10 +28,7 @@ func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, e
 	go func(ctx context.Context, b *Backend, name string, pr *io.PipeReader, cancel context.CancelFunc) {
 		// This call returns when the pipe is closed, or when an error occurs.
 		info, err := b.doStoreReader(ctx, name, pr, -1)
-		switch err {
-		case context.DeadlineExceeded:
-			err = context.Cause(ctx)
-		case nil:
+		if err == nil {
 			_ = b.setMarker(ctx, name, info.ETag, false)
 		}
 		_ = pr.CloseWithError(err)
@@ -63,7 +60,7 @@ func (w *writerWrapper) Close() (err error) {
 	err = w.prevErr
 	_ = w.pw.CloseWithError(err)
 	if w.prevErr == nil {
-		w.prevErr = errors.Join(simpleblob.ErrClosed, context.Cause(w.ctx))
+		w.prevErr = simpleblob.ErrClosed
 	}
 	<-w.ctx.Done()
 	return err

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -2,10 +2,10 @@ package s3
 
 import (
 	"context"
+	"errors"
 	"io"
 
 	"github.com/PowerDNS/simpleblob"
-	"github.com/minio/minio-go/v7"
 )
 
 // NewReader satisfies StreamReader and provides a read streaming interface to
@@ -22,60 +22,49 @@ func (b *Backend) NewReader(ctx context.Context, name string) (io.ReadCloser, er
 // NewWriter satisfies StreamWriter and provides a write streaming interface to
 // a blob located on an S3 server.
 func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
+	ctx, cancel := context.WithCancel(ctx)
 	name = b.prependGlobalPrefix(name)
 	pr, pw := io.Pipe()
-	w := &writerWrapper{
-		ctx:      ctx,
-		backend:  b,
-		name:     name,
-		pw:       pw,
-		donePipe: make(chan struct{}),
-	}
-	go func() {
-		var err error
-		// The following call will return only on error or
-		// if the writing end of the pipe is closed.
-		// It is okay to write to w.info from this goroutine
-		// because it will only be used after w.donePipe is closed.
-		w.info, err = w.backend.doStoreReader(w.ctx, w.name, pr, -1)
-		_ = pr.CloseWithError(err) // Always returns nil.
-		close(w.donePipe)
-	}()
-	return w, nil
+	go func(ctx context.Context, b *Backend, name string, pr *io.PipeReader, cancel context.CancelFunc) {
+		// This call returns when the pipe is closed, or when an error occurs.
+		info, err := b.doStoreReader(ctx, name, pr, -1)
+		switch err {
+		case context.DeadlineExceeded:
+			err = context.Cause(ctx)
+		case nil:
+			_ = b.setMarker(ctx, name, info.ETag, false)
+		}
+		_ = pr.CloseWithError(err)
+		cancel()
+	}(ctx, b, name, pr, cancel)
+	return &writerWrapper{b, nil, ctx, pw}, nil
 }
 
-// A writerWrapper implements io.WriteCloser and is returned by (*Backend).NewWriter.
+// A writerWrapper allows storing data on S3 through a io.WriteCloser.
 type writerWrapper struct {
 	backend *Backend
-
-	// We need to keep these around
-	// to write the marker in Close.
-	ctx  context.Context
-	info minio.UploadInfo
-	name string
-
-	// Writes are sent to this pipe
-	// and then written to S3 in a background goroutine.
-	pw       *io.PipeWriter
-	donePipe chan struct{}
+	prevErr error // never nil after Close has been called
+	ctx     context.Context
+	pw      *io.PipeWriter
 }
 
-func (w *writerWrapper) Write(p []byte) (int, error) {
+// Write sends p to store as the S3 object associated with w.
+// An error is returned if Write failed previously, an error occured on the S3 side, or w is already closed.
+func (w *writerWrapper) Write(p []byte) (n int, err error) {
 	// Not checking the status of ctx explicitly because it will be propagated
 	// from the reader goroutine.
-	return w.pw.Write(p)
+	n, w.prevErr = w.pw.Write(p)
+	return n, w.prevErr
 }
 
-func (w *writerWrapper) Close() error {
-	select {
-	case <-w.donePipe:
-		return simpleblob.ErrClosed
-	default:
+// Close ensures that the written data is saved.
+// An error is returned if Write failed previously, an error occured on the S3 side, or w is already closed.
+func (w *writerWrapper) Close() (err error) {
+	err = w.prevErr
+	_ = w.pw.CloseWithError(err)
+	if w.prevErr == nil {
+		w.prevErr = errors.Join(simpleblob.ErrClosed, context.Cause(w.ctx))
 	}
-	_ = w.pw.Close() // Always returns nil.
-	<-w.donePipe     // Wait for doStoreReader to return and w.info to be set.
-	return w.backend.setMarker(w.ctx, w.name, w.info.ETag, false)
+	<-w.ctx.Done()
+	return err
 }

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -3,8 +3,6 @@ package s3
 import (
 	"context"
 	"io"
-
-	"github.com/PowerDNS/simpleblob"
 )
 
 // NewReader satisfies StreamReader and provides a read streaming interface to
@@ -39,7 +37,6 @@ func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, e
 // A writerWrapper allows storing data on S3 through a io.WriteCloser.
 type writerWrapper struct {
 	backend *Backend
-	prevErr error // never nil after Close has been called
 	ctx     context.Context
 	pw      *io.PipeWriter
 }
@@ -49,24 +46,16 @@ type writerWrapper struct {
 func (w *writerWrapper) Write(p []byte) (int, error) {
 	// Not checking the status of ctx explicitly because it will be propagated
 	// from the reader goroutine.
-	if w.prevErr != nil {
-		return 0, w.prevErr
-	}
-	n, err := w.pw.Write(p)
-	if err != nil {
-		w.prevErr = err
-	}
-	return n, err
+	return w.pw.Write(p)
 }
 
 // Close ensures that the written data is saved.
 // An error is returned if Write failed previously, an error occurred in S3, or w is already closed.
-func (w *writerWrapper) Close() (err error) {
-	err = w.prevErr
-	_ = w.pw.CloseWithError(err)
-	if w.prevErr == nil {
-		w.prevErr = simpleblob.ErrClosed
-	}
+func (w *writerWrapper) Close() error {
+	_, err := w.pw.Write(nil)
+	_ = w.pw.Close()
+	// Let the reading goroutine finish writing,
+	// and write the marker if needed.
 	<-w.ctx.Done() // cancelled after writing the marker
 	return err
 }

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -3,7 +3,6 @@ package s3
 import (
 	"context"
 	"io"
-	"sync"
 )
 
 // NewReader satisfies StreamReader and provides a read streaming interface to
@@ -20,24 +19,25 @@ func (b *Backend) NewReader(ctx context.Context, name string) (io.ReadCloser, er
 // NewWriter satisfies StreamWriter and provides a write streaming interface to
 // a blob located on an S3 server.
 func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, error) {
+	ctx, cancel := context.WithCancel(ctx)
 	name = b.prependGlobalPrefix(name)
 	pr, pw := io.Pipe()
-	w := &writerWrapper{pw: pw}
-	w.wg.Go(func() {
+	go func(ctx context.Context, b *Backend, name string, pr *io.PipeReader, cancel context.CancelFunc) {
 		// This call returns when the pipe is closed, or when an error occurs.
 		info, err := b.doStoreReader(ctx, name, pr, -1)
 		if err == nil {
 			_ = b.setMarker(ctx, name, info.ETag, false)
 		}
 		_ = pr.CloseWithError(err)
-	})
-	return w, nil
+		cancel()
+	}(ctx, b, name, pr, cancel)
+	return &writerWrapper{ctx: ctx, pw: pw}, nil
 }
 
 // A writerWrapper allows storing data on S3 through a io.WriteCloser.
 type writerWrapper struct {
-	wg sync.WaitGroup
-	pw *io.PipeWriter
+	ctx context.Context
+	pw  *io.PipeWriter
 }
 
 // Write sends p to store as the S3 object associated with w.
@@ -55,6 +55,6 @@ func (w *writerWrapper) Close() error {
 	_ = w.pw.Close()
 	// Let the reading goroutine finish writing,
 	// and write the marker if needed.
-	w.wg.Wait()
+	<-w.ctx.Done() // cancelled after writing the marker
 	return err
 }

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -45,7 +45,7 @@ type writerWrapper struct {
 }
 
 // Write sends p to store as the S3 object associated with w.
-// An error is returned if Write failed previously, an error occured in S3, or w is already closed.
+// An error is returned if Write failed previously, an error occurred in S3, or w is already closed.
 func (w *writerWrapper) Write(p []byte) (n int, err error) {
 	// Not checking the status of ctx explicitly because it will be propagated
 	// from the reader goroutine.
@@ -54,7 +54,7 @@ func (w *writerWrapper) Write(p []byte) (n int, err error) {
 }
 
 // Close ensures that the written data is saved.
-// An error is returned if Write failed previously, an error occured in S3, or w is already closed.
+// An error is returned if Write failed previously, an error occurred in S3, or w is already closed.
 func (w *writerWrapper) Close() (err error) {
 	err = w.prevErr
 	_ = w.pw.CloseWithError(err)

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -2,7 +2,6 @@ package s3
 
 import (
 	"context"
-	"errors"
 	"io"
 
 	"github.com/PowerDNS/simpleblob"

--- a/backends/s3/stream.go
+++ b/backends/s3/stream.go
@@ -33,7 +33,7 @@ func (b *Backend) NewWriter(ctx context.Context, name string) (io.WriteCloser, e
 		_ = pr.CloseWithError(err)
 		cancel()
 	}(ctx, b, name, pr, cancel)
-	return &writerWrapper{b, nil, ctx, pw}, nil
+	return &writerWrapper{backend: b, ctx: ctx, pw: pw}, nil
 }
 
 // A writerWrapper allows storing data on S3 through a io.WriteCloser.


### PR DESCRIPTION
Refactor the `io.WriteCloser` returned by `(*s3.Backend).NewWriter` to make it more robust and simple. It takes some changes out of #133, that will be rebased to result in a simpler and more obvious diff.