### PR TITLE
cleanup of backends/azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .*.swp
 *~
 /tmp
-/bin/*
+/bin
 .DS_Store

--- a/backends/azure/azure.go
+++ b/backends/azure/azure.go
@@ -19,7 +19,6 @@ import (
 	"github.com/PowerDNS/go-tlsconfig"
 	"github.com/PowerDNS/simpleblob"
 	"github.com/go-logr/logr"
-	"github.com/sirupsen/logrus"
 )
 
 // Azure blob implementation examples can be found here:
@@ -34,12 +33,24 @@ const (
 	// DefaultUpdateMarkerForceListInterval is the default value for
 	// UpdateMarkerForceListInterval.
 	DefaultUpdateMarkerForceListInterval = 5 * time.Minute
+	// DefaultSecretsRefreshInterval is the default value for SecretsRefreshInterval.
+	// It should not be too high so as to retrieve secrets regularly.
+	DefaultSecretsRefreshInterval = 15 * time.Second
 )
 
 type Options struct {
 	// AccountName and AccountKey are statically defined here.
 	AccountName string `yaml:"account_name"`
 	AccountKey  string `yaml:"account_key"`
+
+	// Path to the file containing the account key as an alternative to
+	// AccountKey, e.g. /run/secrets/simpleblob-azure-account-key.
+	AccountKeyFile string `yaml:"account_key_file"`
+
+	// Time between each secrets retrieval. Minimum is 1s, lower values are
+	// considered an error. It defaults to DefaultSecretsRefreshInterval, which
+	// is currently 15s.
+	SecretsRefreshInterval time.Duration `yaml:"secrets_refresh_interval"`
 
 	UseSharedKey bool `yaml:"use_shared_key"`
 
@@ -136,10 +147,15 @@ func (o Options) Check() error {
 		return fmt.Errorf("azure storage.options: container is required")
 	}
 
+	if o.AccountName == "" && o.EndpointURL == "" {
+		return fmt.Errorf("azure storage.options: account_name is required if endpoint_url is not set")
+	}
+
 	if o.UseSharedKey {
-		hasSecretsCreds := o.AccountName != "" && o.AccountKey != ""
-		if !hasSecretsCreds {
-			return fmt.Errorf("azure storage.options: account_name and account_key are required when use_shared_key is true")
+		hasStaticCreds := o.AccountName != "" && o.AccountKey != ""
+		hasSecretsCreds := o.AccountName != "" && o.AccountKeyFile != ""
+		if !hasStaticCreds && !hasSecretsCreds {
+			return fmt.Errorf("azure storage.options: account_name and either account_key or account_key_file are required when use_shared_key is true")
 		}
 	}
 
@@ -213,10 +229,6 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		opt.EndpointURL = fmt.Sprintf("https://%s.blob.core.windows.net", opt.AccountName)
 	}
 
-	// Some of the following calls require a short running context
-	ctx, cancel := context.WithTimeout(ctx, opt.InitTimeout)
-	defer cancel()
-
 	// Default path: let the Azure SDK decide how to authenticate
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
 	if err != nil {
@@ -228,14 +240,25 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		return nil, err
 	}
 
-	// If UseSharedKey is true, authenticate using shared key credentials with AccountName and AccountKey.
+	// If UseSharedKey is true, authenticate using shared key credentials with AccountName and AccountKey/AccountKeyFile.
 	// Otherwise, DefaultAzureCredential is used (service principal via environment variables).
-	// https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/azidentity/README.md#service-principal-with-secret
 	if opt.UseSharedKey {
-		if opt.AccountName == "" || opt.AccountKey == "" {
-			return nil, errors.New("AccountName and AccountKey are required when UseSharedKey is true")
+		updateSecret := func() (bool, error) {
+			// Initial load.
+			data, err := os.ReadFile(opt.AccountKeyFile)
+			if err != nil {
+				return false, err
+			}
+			changed := opt.AccountKey != string(data)
+			opt.AccountKey = string(data)
+			return changed, nil
 		}
-
+		if opt.AccountKeyFile != "" {
+			_, err := updateSecret()
+			if err != nil {
+				return nil, fmt.Errorf("failed to read account key from secret %q: %w", opt.AccountKeyFile, err)
+			}
+		}
 		cred, err := azblob.NewSharedKeyCredential(opt.AccountName, opt.AccountKey)
 		if err != nil {
 			return nil, err
@@ -245,7 +268,36 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if opt.AccountKeyFile != "" {
+			go func() {
+				c := time.Tick(opt.SecretsRefreshInterval)
+				for {
+					select {
+					case <-c:
+						changed, err := updateSecret()
+						if err != nil {
+							log.Error(err, "failed to read account key from secret", "account_key_file", opt.AccountKeyFile)
+						}
+						if changed {
+							err := cred.SetAccountKey(opt.AccountKey)
+							if err != nil {
+								log.Error(err, "failed to set account key from secret", "account_key_file", opt.AccountKeyFile)
+							} else {
+								log.Info("updated account key from secret", "account_key_file", opt.AccountKeyFile)
+							}
+						}
+					case <-ctx.Done():
+						return
+					}
+				}
+			}()
+		}
 	}
+
+	// Some of the following calls require a short running context
+	ctx, cancel := context.WithTimeout(ctx, opt.InitTimeout)
+	defer cancel()
 
 	if opt.CreateContainer {
 		// Create bucket if it does not exist
@@ -253,12 +305,8 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		metricLastCallTimestamp.WithLabelValues("create-container").SetToCurrentTime()
 
 		_, err := client.CreateContainer(ctx, opt.Container, &azblob.CreateContainerOptions{})
-		if err != nil {
-			if bloberror.HasCode(err, bloberror.ContainerAlreadyExists) {
-				logrus.WithField("storage_type", "Azure").Infof("Container already exists: %s", opt.Container)
-			} else {
-				return nil, err
-			}
+		if err != nil && !bloberror.HasCode(err, bloberror.ContainerAlreadyExists) {
+			return nil, err
 		}
 	}
 

--- a/backends/azure/azure.go
+++ b/backends/azure/azure.go
@@ -6,11 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
@@ -21,8 +23,7 @@ import (
 )
 
 // Azure blob implementation examples can be found here:
-//https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/storage/azblob/examples_test.go
-
+// https://github.com/Azure/azure-sdk-for-go/blob/main/sdk/storage/azblob/examples_test.go
 const (
 	// DefaultInitTimeout is the time we allow for initialisation, like credential
 	// checking and bucket creation. We define this here, because we do not
@@ -33,14 +34,9 @@ const (
 	// DefaultUpdateMarkerForceListInterval is the default value for
 	// UpdateMarkerForceListInterval.
 	DefaultUpdateMarkerForceListInterval = 5 * time.Minute
-	// DefaultDisableContentMd5 : disable sending the Content-MD5 header
-	DefaultDisableContentMd5 = false
-	// Max number of concurrent uploads to be performed to upload the file
-	DefaultConcurrency = 1
 )
 
 type Options struct {
-
 	// AccountName and AccountKey are statically defined here.
 	AccountName string `yaml:"account_name"`
 	AccountKey  string `yaml:"account_key"`
@@ -57,11 +53,8 @@ type Options struct {
 	// seamlessly
 	GlobalPrefix string `yaml:"global_prefix"`
 
-	// EndpointURL can be set to something like "http://localhost:9000" for local testing
+	// EndpointURL can be set to something like "http://localhost:10000" for Azurite
 	EndpointURL string `yaml:"endpoint_url"`
-
-	// DisableContentMd5 defines whether to disable sending the Content-MD5 header
-	DisableContentMd5 bool `yaml:"disable_send_content_md5"`
 
 	// TLS allows customising the TLS configuration
 	// See https://github.com/PowerDNS/go-tlsconfig for the available options
@@ -71,6 +64,35 @@ type Options struct {
 	// checking and bucket creation. It defaults to DefaultInitTimeout, which
 	// is currently 20s.
 	InitTimeout time.Duration `yaml:"init_timeout"`
+
+	// IdleConnTimeout is the maximum amount of time an idle
+	// (keep-alive) connection will remain idle before closing
+	// itself. Default if unset: 90s
+	IdleConnTimeout time.Duration `yaml:"idle_conn_timeout"`
+
+	// MaxIdleConns controls the maximum number of idle (keep-alive)
+	// connections. Default if unset: 100
+	MaxIdleConns int `yaml:"max_idle_conns"`
+
+	// DialTimeout is the maximum amount of time a dial will wait for
+	// a connect to complete. Default if unset: 10s
+	DialTimeout time.Duration `yaml:"dial_timeout"`
+
+	// DialKeepAlive specifies the interval between keep-alive
+	// probes for an active network connection. Default if unset: 10s
+	DialKeepAlive time.Duration `yaml:"dial_keep_alive"`
+
+	// TLSHandshakeTimeout specifies the maximum amount of time to
+	// wait for a TLS handshake. Default if unset: 10s
+	TLSHandshakeTimeout time.Duration `yaml:"tls_handshake_timeout"`
+
+	// ClientTimeout specifies a time limit for requests made by this
+	// HTTP Client. The timeout includes connection time, any
+	// redirects, and reading the response body. The timer remains
+	// running after Get, Head, Post, or Do return and will
+	// interrupt reading of the Response.Body.
+	// Default if unset: 15m
+	ClientTimeout time.Duration `yaml:"client_timeout"`
 
 	// UseUpdateMarker makes the backend write and read a file to determine if
 	// it can cache the last List command. The file contains the name of the
@@ -88,9 +110,9 @@ type Options struct {
 	// some reason get out of sync.
 	UpdateMarkerForceListInterval time.Duration `yaml:"update_marker_force_list_interval"`
 
-	// Concurrency defines the max number of concurrent uploads to be performed to upload the file.
-	// Each concurrent upload will create a buffer of size BlockSize.  The default value is one.
-	// https://github.com/Azure/azure-sdk-for-go/blob/e5c902ce7aca5aa0f4c7bb7e46c18c8fc91ad458/sdk/storage/azblob/blockblob/models.go#L264
+	// Concurrency defines the max number of concurrent uploads as defined in
+	// azblob.UploadStreamOptions. The default value there is one.
+	// https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob#UploadStreamOptions.Concurrency
 	Concurrency int `yaml:"concurrency"`
 
 	// Not loaded from YAML
@@ -131,15 +153,9 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	if opt.InitTimeout == 0 {
 		opt.InitTimeout = DefaultInitTimeout
 	}
-
 	if opt.UpdateMarkerForceListInterval == 0 {
 		opt.UpdateMarkerForceListInterval = DefaultUpdateMarkerForceListInterval
 	}
-
-	if opt.Concurrency == 0 {
-		opt.Concurrency = DefaultConcurrency
-	}
-
 	if err := opt.Check(); err != nil {
 		return nil, err
 	}
@@ -150,17 +166,56 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	}
 	log = log.WithName("azure")
 
-	var endpoint string
-
-	accountName := opt.AccountName
-
-	if opt.EndpointURL != "" {
-		endpoint = opt.EndpointURL
-	} else {
-		endpoint = fmt.Sprintf("https://%s.blob.core.windows.net", accountName)
+	// Automatic TLS handling
+	// This MUST receive a longer running context to be able to automatically
+	// reload certificates, so we use the original ctx, not one with added
+	// InitTimeout.
+	tlsmgr, err := tlsconfig.NewManager(ctx, opt.TLS, tlsconfig.Options{
+		IsClient: true,
+		Logr:     log.WithName("tls-manager"),
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	var client *azblob.Client
+	// Create an opinionated HTTP client that:
+	// - Uses a custom tls.Config
+	// - Sets proxies from the environment
+	// - Sets reasonable timeouts on various operations
+	// Based on tlsConfig.HTTPClient(), copied to allow overrides.
+	tlsConfig, err := tlsmgr.TLSConfig()
+	if err != nil {
+		return nil, err
+	}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   getOpt(opt.DialTimeout, 10*time.Second),
+			KeepAlive: getOpt(opt.DialKeepAlive, 10*time.Second),
+		}).DialContext,
+		MaxIdleConns:          getOpt(opt.MaxIdleConns, 100),
+		IdleConnTimeout:       getOpt(opt.IdleConnTimeout, 90*time.Second),
+		TLSHandshakeTimeout:   getOpt(opt.TLSHandshakeTimeout, 10*time.Second),
+		ExpectContinueTimeout: 10 * time.Second,
+		TLSClientConfig:       tlsConfig,
+		ForceAttemptHTTP2:     true,
+	}
+	options := &azblob.ClientOptions{
+		ClientOptions: azcore.ClientOptions{
+			Transport: &http.Client{
+				Transport: transport,
+				Timeout:   getOpt(opt.ClientTimeout, 15*time.Minute),
+			},
+		},
+	}
+
+	if opt.EndpointURL == "" {
+		opt.EndpointURL = fmt.Sprintf("https://%s.blob.core.windows.net", opt.AccountName)
+	}
+
+	// Some of the following calls require a short running context
+	ctx, cancel := context.WithTimeout(ctx, opt.InitTimeout)
+	defer cancel()
 
 	// Default path: let the Azure SDK decide how to authenticate
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -168,7 +223,7 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		return nil, err
 	}
 
-	client, err = azblob.NewClient(endpoint, cred, nil)
+	client, err := azblob.NewClient(opt.EndpointURL, cred, options)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +241,7 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 			return nil, err
 		}
 
-		client, err = azblob.NewClientWithSharedKeyCredential(endpoint, cred, nil)
+		client, err = azblob.NewClientWithSharedKeyCredential(opt.EndpointURL, cred, options)
 		if err != nil {
 			return nil, err
 		}
@@ -198,7 +253,6 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		metricLastCallTimestamp.WithLabelValues("create-container").SetToCurrentTime()
 
 		_, err := client.CreateContainer(ctx, opt.Container, &azblob.CreateContainerOptions{})
-
 		if err != nil {
 			if bloberror.HasCode(err, bloberror.ContainerAlreadyExists) {
 				logrus.WithField("storage_type", "Azure").Infof("Container already exists: %s", opt.Container)
@@ -217,6 +271,14 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	b.setGlobalPrefix(opt.GlobalPrefix)
 
 	return b, nil
+}
+
+func getOpt[T comparable](optVal, defaultVal T) T {
+	var zero T
+	if optVal == zero {
+		return defaultVal
+	}
+	return optVal
 }
 
 func (b *Backend) List(ctx context.Context, prefix string) (blobList simpleblob.BlobList, err error) {
@@ -287,14 +349,16 @@ func (b *Backend) doList(ctx context.Context, prefix string) (simpleblob.BlobLis
 
 	// Runes to strip from blob names for GlobalPrefix
 	// This is fine, because we can trust the API to only return with the prefix.
+	// TODO: trust but verify
 	gpEndIndex := len(b.opt.GlobalPrefix)
 
 	// Use Azure SDK to get blobs from container
-	blobPager := b.client.NewListBlobsFlatPager(b.opt.Container, nil)
+	blobPager := b.client.NewListBlobsFlatPager(b.opt.Container, &azblob.ListBlobsFlatOptions{
+		Prefix: &prefix,
+	})
 
 	for blobPager.More() {
 		resp, err := blobPager.NextPage(ctx)
-
 		if err != nil {
 			return nil, err
 		}
@@ -307,28 +371,20 @@ func (b *Backend) doList(ctx context.Context, prefix string) (simpleblob.BlobLis
 
 		for _, v := range resp.Segment.BlobItems {
 			blobName := *v.Name
-
-			// We have to manually check for prefix since Azure doesn't support querying by prefix
-			if !strings.HasPrefix(blobName, prefix) {
-				continue
-			}
-
 			if blobName == b.markerName {
 				continue
 			}
 
-			size := *v.Properties.ContentLength
-
+			// Strip global prefix from blob
 			if gpEndIndex > 0 {
 				blobName = blobName[gpEndIndex:]
 			}
 
-			blobs = append(blobs, simpleblob.Blob{Name: blobName, Size: size})
+			blobs = append(blobs, simpleblob.Blob{Name: blobName, Size: *v.Properties.ContentLength})
 		}
 	}
 
-	// Sort explicitly.
-	blobs.Sort()
+	metricLastCallTimestamp.WithLabelValues("list").SetToCurrentTime()
 
 	return blobs, nil
 }
@@ -378,7 +434,6 @@ func (b *Backend) Store(ctx context.Context, name string, data []byte) error {
 	name = b.prependGlobalPrefix(name)
 
 	info, err := b.doStore(ctx, name, data)
-
 	if err != nil {
 		return err
 	}
@@ -403,7 +458,6 @@ func (b *Backend) doStoreReader(ctx context.Context, name string, r io.Reader, s
 
 	// Perform UploadStream
 	resp, err := b.client.UploadStream(ctx, b.opt.Container, name, r, uploadStreamOptions)
-
 	if err != nil {
 		metricCallErrors.WithLabelValues("store").Inc()
 		return azblob.UploadStreamResponse{}, err

--- a/backends/azure/azure.go
+++ b/backends/azure/azure.go
@@ -157,6 +157,9 @@ func (o Options) Check() error {
 		if !hasStaticCreds && !hasSecretsCreds {
 			return fmt.Errorf("azure storage.options: account_name and either account_key or account_key_file are required when use_shared_key is true")
 		}
+		if hasSecretsCreds && o.SecretsRefreshInterval < time.Second {
+			return fmt.Errorf("azure storage.options: field secrets_refresh_interval must be at least 1s")
+		}
 	}
 
 	return nil
@@ -171,6 +174,9 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 	}
 	if opt.UpdateMarkerForceListInterval == 0 {
 		opt.UpdateMarkerForceListInterval = DefaultUpdateMarkerForceListInterval
+	}
+	if opt.SecretsRefreshInterval == 0 {
+		opt.SecretsRefreshInterval = DefaultSecretsRefreshInterval
 	}
 	if err := opt.Check(); err != nil {
 		return nil, err

--- a/backends/s3/s3.go
+++ b/backends/s3/s3.go
@@ -187,7 +187,6 @@ type Backend struct {
 	opt        Options
 	config     *minio.Options
 	client     *minio.Client
-	log        logr.Logger
 	markerName string
 
 	mu         sync.Mutex
@@ -547,7 +546,6 @@ func New(ctx context.Context, opt Options) (*Backend, error) {
 		opt:    opt,
 		config: cfg,
 		client: client,
-		log:    log,
 	}
 	b.setGlobalPrefix(opt.GlobalPrefix)
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/PowerDNS/simpleblob
 go 1.25.0
 
 require (
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3
 	github.com/PowerDNS/go-tlsconfig v0.0.0-20221101135152-0956853b28df
@@ -10,7 +11,6 @@ require (
 	github.com/minio/minio-go/v7 v7.0.99
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/common v0.67.5
-	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
 	github.com/testcontainers/testcontainers-go/modules/azure v0.41.0
@@ -20,7 +20,6 @@ require (
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
@@ -74,6 +73,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/rs/xid v1.6.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.2 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/tinylib/msgp v1.6.1 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect

--- a/test.sh
+++ b/test.sh
@@ -38,7 +38,7 @@ echo
 echo 'Running linters'
 expected_version=2.11.3
 golangci_lint_bin=./bin/golangci-lint
-if ! "$golangci_lint_bin" version | grep -wq "version $expected_version"; then
+if [ "$("$golangci_lint_bin" version --short)" != "$expected_version" ]; then
     # This is the recommended installation process.
     # The installer downloads to ./bin/ by default.
     # see https://golangci-lint.run/usage/install/


### PR DESCRIPTION
* implemented TLS config and re-added timeouts like backends/s3
* cleaned up unused Options
* changed List to pass the prefix upstream
* implemented AccountKeyFile and SecretsRefreshInterval options (for #127)

After this change is merged (and released) I can continue with PowerDNS/lightningstream#121 